### PR TITLE
Modernise darts python code & Makefile fixes

### DIFF
--- a/darts/mpi-mkl/c/Makefile
+++ b/darts/mpi-mkl/c/Makefile
@@ -3,14 +3,14 @@
 # Compiler definition
 # If running on Cray use compiler wrapper cc instead of directly using Intel/GNU/PGI compiler. Consider swapping to an appropriate PrgEnv- module.
 # On other systems load appropriate MPI module and use: mpicc
-MPICC = cc
+MPICC = ${CC}
 
 # Optimisation level set to -O2
 # Debugging enabled if using -g
 CFLAGS = -O2 -g
 
 # Setup include directory and libraries for MKL. Use the Intel MKL Link Line Advisor
-MKL_LIBS=-Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_sequential.a ${MKLROOT}/lib/intel64/libmkl_core.a -Wl,--end-group -lpthread -lm
+MKL_LIBS=-Wl,--start-group -L${MKLROOT}/lib/intel64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core  -Wl,--end-group -lpthread -lm
 MKL_INCL=-DMKL_ILP64 -I$(MKLROOT)/include
 
 # Default target  

--- a/darts/openmp/c/Makefile
+++ b/darts/openmp/c/Makefile
@@ -3,14 +3,13 @@
 # Compiler definition
 # If running on Cray use compiler wrapper cc instead of directly using Intel/GNU/PGI compiler. Consider swapping to an appropriate PrgEnv- module.
 # On other systems use: gcc (for GNU), icc (for Intel), pgcc (PGI)
-CC = cc
 
 # Optimisation level set to -O2
 # Debugging enabled if using -g
 # Notice that OpenMP flag differs for different compiler families
 # Use: -fopenmp (for GNU), -qopenmp (for Intel), -mp (for PGI)
 # OpenMP is enabled by default for Cray compiler.
-CFLAGS = -O2 -g -qopenmp
+CFLAGS = -O2 -g
 
 # Default target  
 all: darts-omp

--- a/darts/openmp/c/Makefile
+++ b/darts/openmp/c/Makefile
@@ -10,8 +10,30 @@
 # Use: -fopenmp (for GNU), -qopenmp (for Intel), -mp (for PGI)
 # OpenMP is enabled by default for Cray compiler.
 CFLAGS = -O2 -g
+CC_NAME=$(shell $(CC) 2>&1 | head -n 1 | grep -m 1 -oE "(gcc|g++|icc|icpc|pgi)" | head -n 1)
 
+ifeq ($(CC_NAME), icc)
+CFLAGS += -qopenmp
+endif
+
+ifeq ($(CC_NAME), icpc)
+CFLAGS += -qopenmp
+endif
+
+ifeq ($(CC_NAME), pgi)   
+CFLAGS += -mp
+endif 
+
+ifeq ($(CC_NAME), gcc)   
+CFLAGS += -fopenmp
+endif 
+
+ifeq ($(CC_NAME), g++)   
+CFLAGS += -fopenmp
+endif 
+#
 # Default target  
+
 all: darts-omp
 
 darts-omp: darts-omp.o 

--- a/darts/openmp/fortran/Makefile
+++ b/darts/openmp/fortran/Makefile
@@ -10,7 +10,22 @@ F90?=${FC}
 # Notice that OpenMP flag differs for different compiler families
 # Use: -fopenmp (for GNU), -qopenmp (for Intel), -mp (for PGI)
 # OpenMP is enabled by default for Cray compiler.
+
 FFLAGS = -O2 -g
+F90_NAME=$(shell $(F90) 2>&1 | head -n 1 | grep -m 1 -oE "(gfortran|ifort|pgf)" | head -n 1)
+
+ifeq ($(F90_NAME), ifort)
+FFLAGS += -qopenmp
+endif
+
+ifeq ($(F90_NAME), pgf)   
+FFLAGS += -mp
+endif 
+
+ifeq ($(F90_NAME), gfortran)   
+FFLAGS += -fopenmp
+endif 
+
 
 darts-omp: darts-omp.o
 	${F90} ${FFLAGS} -o darts-omp darts-omp.o

--- a/darts/openmp/fortran/Makefile
+++ b/darts/openmp/fortran/Makefile
@@ -3,14 +3,14 @@
 # Compiler definition
 # If running on Cray use compiler wrapper ftn instead of directly using Intel/GNU/PGI compiler. Consider swapping to an appropriate PrgEnv- module.
 # On other systems use: gfortran (for GNU), ifort (for Intel), pgf90 (PGI)
-F90 = ftn
+F90?=${FC}
 
 # Optimisation level set to -O2
 # Debugging enabled if using -g
 # Notice that OpenMP flag differs for different compiler families
 # Use: -fopenmp (for GNU), -qopenmp (for Intel), -mp (for PGI)
 # OpenMP is enabled by default for Cray compiler.
-FFLAGS = -O2 -g -qopenmp
+FFLAGS = -O2 -g
 
 darts-omp: darts-omp.o
 	${F90} ${FFLAGS} -o darts-omp darts-omp.o

--- a/darts/serial/c/Makefile
+++ b/darts/serial/c/Makefile
@@ -1,10 +1,5 @@
 # Makefile to compile Darts serial C code
-
-# Compiler definition
-# If running on Cray use compiler wrapper cc instead of directly using Intel/GNU/PGI compiler. Consider swapping to an appropriate PrgEnv- module.
-# On other systems use: gcc (for GNU), icc (for Intel), pgcc (PGI)
-CC = icc
-
+CC?=mpicc
 # Optimisation level set to -O2
 # Debugging enabled if using -g
 CFLAGS = -O2 -g

--- a/darts/serial/fortran/Makefile
+++ b/darts/serial/fortran/Makefile
@@ -3,7 +3,7 @@
 # Compiler definition
 # If running on Cray use compiler wrapper ftn instead of directly using Intel/GNU/PGI compiler. Consider swapping to an appropriate PrgEnv- module.
 # On other systems use: gfortran (for GNU), ifort (for Intel), pgf90 (PGI)
-F90 = ftn
+F90?=${FC}
 
 # Optimisation level set to -O2
 # Debugging enabled if using -g

--- a/darts/serial/python/darts.py
+++ b/darts/serial/python/darts.py
@@ -1,18 +1,16 @@
+from random import random
 
-import numpy.random as rng
-
-num_trials = 10**6
+num_trials = 2*10**6
 r = 1.0
 r2 = r * r
-
 Ncirc = 0
+
 for _ in range(num_trials):
-    x = rng.random() 
-    y = rng.random()
-    if ( x**2 + y**2 < r2 ):
-	Ncirc +=1 
+    x = random() 
+    y = random()
+    if x**2 + y**2 < r2:
+        Ncirc += 1 
 
-pi = 4.0 * ( float(Ncirc) / float(num_trials) ) 
+pi = 4.0 * (float(Ncirc) / float(num_trials)) 
 
-print("\n \t Computing pi in serial: \n")
-print("\t For %d trials, pi = %f\n" % (num_trials,pi))
+print(f"Computing pi in serial:\n\tFor {num_trials} trials, pi = {pi}\n")

--- a/darts/serial/python/job.slurm
+++ b/darts/serial/python/job.slurm
@@ -8,6 +8,6 @@
 #SBATCH --time=00:05:00
 #SBATCH --export=NONE
 
-module load python
+module load python/3.6.3
 
-srun --export=all -n 1 python ./darts.py
+srun --export=all -n 1 python3 ./darts.py


### PR DESCRIPTION
Python code for darts mixed tabs and spaces which is not possible anymore. Replaced use of numpy.random with the Python random module. Increased number of trials because sometimes the test failed.

- Fixes Makefile variables